### PR TITLE
Current screen resolution fix

### DIFF
--- a/src/main/java/com/aimmac23/node/RobotScreenshotSource.java
+++ b/src/main/java/com/aimmac23/node/RobotScreenshotSource.java
@@ -43,8 +43,8 @@ public class RobotScreenshotSource implements ScreenshotSource {
 
 	protected Rectangle getScreenSize() {
 		//XXX: This probably won't work with multiple monitors
-		return GraphicsEnvironment.getLocalGraphicsEnvironment().
-				getDefaultScreenDevice().getDefaultConfiguration().getBounds();
+		DisplayMode displayMode = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDisplayMode();
+		return new Rectangle(displayMode.getWidth(), displayMode.getHeight());
 		
 	}
 


### PR DESCRIPTION
DefaultConfiguration of screen does not handle resolution changes. My grid supports different screen resolutions so when the test begins screen resolution is updated but getScreenSize() function always returns default (best) resolution. i need current resolution of screen