### PR TITLE
Take screenshots using RobotScreenshotSource

### DIFF
--- a/src/main/java/com/aimmac23/node/RobotScreenshotSource.java
+++ b/src/main/java/com/aimmac23/node/RobotScreenshotSource.java
@@ -23,7 +23,7 @@ public class RobotScreenshotSource implements ScreenshotSource {
 	
 	@Override
 	public int applyScreenshot(Pointer encoderContext) {
-		BufferedImage image = robot.createScreenCapture(getScreenSize());
+		BufferedImage image = takeScreenshot();
 
 		int[] screenshotData = ((DataBufferInt)image.getRaster().getDataBuffer()).getData();
 		
@@ -47,6 +47,10 @@ public class RobotScreenshotSource implements ScreenshotSource {
 		DisplayMode displayMode = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDisplayMode();
 		return new Rectangle(displayMode.getWidth(), displayMode.getHeight());
 		
+	}
+	
+	public BufferedImage takeScreenshot(){
+		return robot.createScreenCapture(getScreenSize());
 	}
 
 	@Override


### PR DESCRIPTION
This patch allows to get screenshots from robotscreenshotservice. I need native screenshots and save them to temporary folder on node because selenium default screenshot implemetation sends image data as base64. 
public takeScreenshot function can be used externally.