### PR TITLE
Maven is forcing HTTPS now

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -6,7 +6,7 @@ This guide assumes some familiarity with the Selenium Grid setup guide: https://
 
 Download:
 * The latest "selenium-server-standalone" JAR from http://selenium-release.storage.googleapis.com/index.html
-* The latest "selenium-video-node" JAR from http://repo1.maven.org/maven2/com/aimmac23/selenium-video-node/
+* The latest "selenium-video-node" JAR from https://repo1.maven.org/maven2/com/aimmac23/selenium-video-node/
 
 ### Node setup
 


### PR DESCRIPTION
```
501 HTTPS Required. 
Use https://repo1.maven.org/maven2/
More information at https://links.sonatype.com/central/501-https-required
```